### PR TITLE
fix: lex long strings with quotes inside

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/knakk/rdf
+
+go 1.25.0

--- a/lex.go
+++ b/lex.go
@@ -688,11 +688,17 @@ outer:
 			// reached end of Literal
 			if quoteCount == 3 {
 				// Triple-quoted strings can contain quotes, as long as not 3 in a row.
-				if l.next() != quote {
-					break
+				q2 := l.next()
+				if q2 != quote {
+					l.backup() // back to q2
+					r = l.next()
+					continue
 				}
-				if l.next() != quote {
-					break
+				q3 := l.next()
+				if q3 != quote {
+					l.backup() // back to q3
+					r = l.next()
+					continue
 				}
 			}
 			l.pos -= quoteCount

--- a/lex_test.go
+++ b/lex_test.go
@@ -175,6 +175,14 @@ two
 			{tokenLiteral3, "one\ntwo\n3"},
 			{tokenEOF, ""}},
 		},
+		{`"""a"b""c"""`, []testToken{
+			{tokenLiteral3, `a"b""c`},
+			{tokenEOF, ""}},
+		},
+		{`'''a'b''c'''`, []testToken{
+			{tokenLiteral3, `a'b''c`},
+			{tokenEOF, ""}},
+		},
 		{`"æøå üçgen こんにちは" # comments text`, []testToken{
 			{tokenLiteral, "æøå üçgen こんにちは"},
 			{tokenEOF, ""}},


### PR DESCRIPTION
The turtle parser was unable to parse a long triple-quoted string which contained quotes inside. This MR fixes that. 

Also, initializes a go.mod.
